### PR TITLE
Restructure for service

### DIFF
--- a/HiveLoadGIFTS_alignments_conf.pm
+++ b/HiveLoadGIFTS_alignments_conf.pm
@@ -15,6 +15,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=head1 NAME
+
+ HiveLoadGIFTS_alignments_conf;
+
+=head1 DESCRIPTION
+
+ Export Ensembl genes from core databases.
+ 
+ Mandatory parameters without default values:
+  -registry_host    mysql server with core databases
+  -registry_port    mysql port number
+  -registry_user    read-only user
+  -uniprot_dir      path to UniProt fasta files
+  -rest_server      GIFTS REST API server URL
+  -base_output_dir  Location of output files
+
 =cut
 
 package HiveLoadGIFTS_alignments_conf;
@@ -22,425 +38,353 @@ package HiveLoadGIFTS_alignments_conf;
 use warnings;
 use strict;
 use feature 'say';
-use File::Spec::Functions;
 
-use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
-use base ('Bio::EnsEMBL::Analysis::Hive::Config::HiveBaseConfig_conf');
-
-use Bio::EnsEMBL::ApiVersion qw/software_version/;
+use base ('HiveLoadGIFTS_conf');
 
 sub default_options {
   my ($self) = @_;
   return {
-    # inherit other stuff from the base class
-	  %{ $self->SUPER::default_options() },
+    %{$self->SUPER::default_options},
 
-'pipeline_name' => 'gifts_alignments_loading',
-'pipeline_comment_perfect_match' => 'Perfect matches between Ensembl and UniProt proteins.',
-'pipeline_comment_blast_cigar' => 'Blasts and cigars between Ensembl and UniProt proteins.',
+    pipeline_name => 'gifts_alignments_loading',
 
-'enscode_root_dir' => '/path/to/enscode/',
-'userstamp' => 'ensembl_gifts_loading_pipeline', # username to be registered as the one loading the Ensembl data
-#'user_r' => '', # read-only user
-'user_w' => '', # write user for the pipeline db
-'password' => '', # write password for the pipeline db
-'driver' => 'mysql',
+    pipeline_comment_perfect_match => 'Perfect matches between Ensembl and UniProt proteins.',
+    pipeline_comment_blast_cigar   => 'Blasts and cigars between Ensembl and UniProt proteins.',
 
-# no need to modify this
-'prepare_uniprot_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/uniprot_fasta_prep.sh',
-'prepare_uniprot_index_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/uniprot_fasta_index_prep.pl',
-'perfect_match_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_perfect_match.pages.pl',
-'blast_cigar_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_blast_cigar.pl',
+    enscode_root_dir             => $self->o('ensembl_cvs_root_dir'),
+    prepare_uniprot_script       => $self->o('enscode_root_dir').'/GIFTS/scripts/uniprot_fasta_prep.sh',
+    prepare_uniprot_index_script => $self->o('enscode_root_dir').'/GIFTS/scripts/uniprot_fasta_index_prep.pl',
+    perfect_match_script         => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_perfect_match.pages.pl',
+    blast_cigar_script           => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_blast_cigar.pl',
 
-'rest_server' => '', # GIFTS REST API server URL
-'latest_release_mapping_history_url' => $self->o('rest_server').'mappings/release_history/latest/assembly/',
-'mappings_by_release_mapping_history_url' => $self->o('rest_server').'/mappings/release_history/',
-'alignment_run_url' => $self->o('rest_server').'alignments/alignment_run/',
-'alignments_by_alignment_run_url' => $self->o('rest_server').'alignments/alignment/alignment_run/',
-'set_alignment_status_url' => $self->o('rest_server').'ensembl/species_history/',
-
-'release' => 95, # ensembl release corresponding to the Ensembl gene set in GIFTS to be used
-
-# server containing the Ensembl core databases containing the gene sets to be used
-'registry_host' => '',
-'registry_user' => '', # read-only user 
-'registry_pass' => '', # read-only password
-'registry_port' => '',
-
-'uniprot_dir' => '/path/to/uniprot/knowledgebase/', # path where the UniProt fasta files are stored
-
-# database details for the eHive pipe database
-'server1' => '',
-'port1' => '',
-'pipeline_dbname' => 'USERNAME_'.$self->o('pipeline_name'), # this db will be created
-
-'pipeline_db' => {
-                    -dbname => $self->o('pipeline_dbname'),
-                    -host   => $self->o('server1'),
-                    -port   => $self->o('port1'),
-                    -user   => $self->o('user_w'),
-                    -pass   => $self->o('password'),
-                    -driver => $self->o('driver'),
-                 },
-
+    latest_release_mapping_history_url      => $self->o('rest_server').'/mappings/release_history/latest/assembly/',
+    mappings_by_release_mapping_history_url => $self->o('rest_server').'/mappings/release_history/',
+    alignment_run_url                       => $self->o('rest_server').'/alignments/alignment_run/',
+    alignments_by_alignment_run_url         => $self->o('rest_server').'/alignments/alignment/alignment_run/',
+    set_alignment_status_url                => $self->o('rest_server'),
   };
 }
 
-sub pipeline_create_commands {
-    my ($self) = @_;
-    return [
-      # inheriting database and hive tables' creation
-	    @{$self->SUPER::pipeline_create_commands},
-    ];
-  }
+sub pipeline_wide_parameters {
+  my ($self) = @_;
+  
+  return {
+    %{$self->SUPER::pipeline_wide_parameters},
+    'import_species_data_file'      => 'ensembl_import_species_data.out',
+    'perfect_alignment_run_id_file' => 'perfect_alignment_run_id.out',
+    'blast_alignment_run_id_file'   => 'blast_alignment_run_id.out',
 
+    # These files will be created during the 'prepare_uniprot_files' analysis
+    # from the uniprot_dir files and they will be used by the perfect match alignment script
+    'uniprot_sp_file'         => 'uniprot_sp.cleaned.fa.gz',
+    'uniprot_sp_isoform_file' => 'uniprot_sp_isoforms.cleaned.fa.gz',
+    'uniprot_tr_dir'          => 'trembl20/',
+  };
+}
 
-## See diagram for pipeline structure
 sub pipeline_analyses {
-    my ($self) = @_;
+  my ($self) = @_;
 
-    return [
-       {
-         -input_ids  => [
-                          {
-                            assembly => 'GRCh38',
-                            species => 'homo_sapiens',
-                            output_dir => '/path/to/output_dir/#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                            'perfect_match_alignments_output_file' => '#output_dir#/perfect_match_alignments.out',
-                            'perfect_alignment_run_id_output_file' => '#output_dir#/perfect_alignment_run_id.out',
-                            'blast_alignment_run_id_output_file' => '#output_dir#/blast_alignment_run_id.out',
-
-                            # these files will be created during the 'prepare_uniprot_files' analysis
-                            # from the uniprot_dir files above and they will be used by the perfect match alignment script
-                            'uniprot_sp_file' => '#output_dir#/uniprot_sp.cleaned.fa.gz',
-                            'uniprot_sp_isoform_file' => '#output_dir#/uniprot_sp_isoforms.cleaned.fa.gz',
-                            'uniprot_tr_dir' => '#output_dir#/trembl20/',
-                          },
-                          {
-                            assembly => 'GRCm38',
-                            species => 'mus_musculus',
-                            output_dir => '/path/to/output_dir/#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                            'perfect_match_alignments_output_file' => '#output_dir#/perfect_match_alignments.out',
-                            'perfect_alignment_run_id_output_file' => '#output_dir#/perfect_alignment_run_id.out',
-                            'blast_alignment_run_id_output_file' => '#output_dir#/blast_alignment_run_id.out',
-
-                            # these files will be created during the 'prepare_uniprot_files' analysis
-                            # from the uniprot_dir files above and they will be used by the perfect match alignment script
-                            'uniprot_sp_file' => '#output_dir#/uniprot_sp.cleaned.fa.gz',
-                            'uniprot_sp_isoform_file' => '#output_dir#/uniprot_sp_isoforms.cleaned.fa.gz',
-                            'uniprot_tr_dir' => '#output_dir#/trembl20/',
-                          }
-         ],
-       
-
+  return [
+    {
+      -logic_name => 'submit',
+      -module     => 'Bio::EnsEMBL::GIFTS::Submit',
+      -parameters => {
+                       species_list    => $self->o('species_list'),
+                       base_output_dir => $self->o('base_output_dir'),
+                       tag             => $self->o('tag'),
+                       timestamp       => $self->o('timestamp'),
+                       email           => $self->o('email'),
+                     },
+      -rc_name    => 'default',
+      -flow_into  => {
+                       '1'    => ['?table_name=gifts_submission'],
+                       '2->A' => ['wait_for_uniprot_mappings'],
+                       'A->3' => ['notify'],
+                     },
+    },
+  
+    {
       # Loop for 7 days maximum to detect if the UniProt mappings have been loaded into
       # the GIFTS database for the given ensembl_species_history_id.
 
-        -logic_name => 'wait_for_uniprot_mappings',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+      -logic_name => 'wait_for_uniprot_mappings',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
 
-                          # 7 days (604800s) max checking every 10 minutes (600s)
-                          cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #import_species_data_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-                                 'end=$((SECONDS+604800));'.
-                                 'while [[ ( $SECONDS -lt $end ) && '.
-                                 '         ( '.
-                                 '           ( $ENSEMBLSPECIESHISTORYID != $ENSEMBLSPECIESHISTORYID_IN_RMH ) || '.
-                                 '           ( ( $ENSEMBLSPECIESHISTORYID == $ENSEMBLSPECIESHISTORYID_IN_RMH ) && ( $STATUS != "MAPPING_COMPLETED" ) ) ) ]]; do '.
-                                 
-                                 'echo "Fetching release_mapping_history_id for ensembl_species_history_id $ENSEMBLSPECIESHISTORYID ...";'.
-                                 'ENSEMBLSPECIESHISTORYID_IN_RMH='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".ensembl_species_history.ensembl_species_history_id");'.
+                        # 7 days (604800s) max checking every 10 minutes (600s)
+                        cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #output_dir#/#import_species_data_file#'.
+                               ' | awk \'{print $3}\');'.
+                               'end=$((SECONDS+604800));'.
+                               'while [[ ( $SECONDS -lt $end ) && '.
+                               '         ( '.
+                               '           ( $ENSEMBLSPECIESHISTORYID != $ENSEMBLSPECIESHISTORYID_IN_RMH ) || '.
+                               '           ( ( $ENSEMBLSPECIESHISTORYID == $ENSEMBLSPECIESHISTORYID_IN_RMH ) && ( $STATUS != "MAPPING_COMPLETED" ) ) ) ]]; do '.
+                                                       
+                               'echo "Fetching release_mapping_history_id for ensembl_species_history_id $ENSEMBLSPECIESHISTORYID ...";'.
+                               'ENSEMBLSPECIESHISTORYID_IN_RMH='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".ensembl_species_history.ensembl_species_history_id");'.
 
-                                 'STATUS='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".status");'.
-                                 'sleep 600;'.
-                                 'done;'.
-                                 'if [[ $ENSEMBLSPECIESHISTORYID != $ENSEMBLSPECIESHISTORYID_IN_RMH ]] || '.
-                                 '   [[ $STATUS != "MAPPING_COMPLETED" ]]; then exit -1;fi'
-                       },
-        -rc_name          => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['prepare_uniprot_files'] },
+                               'STATUS='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".status");'.
+                               'sleep 600;'.
+                               'done;'.
+                               'if [[ $ENSEMBLSPECIESHISTORYID != $ENSEMBLSPECIESHISTORYID_IN_RMH ]] || '.
+                               '   [[ $STATUS != "MAPPING_COMPLETED" ]]; then exit -1;fi'
+                     },
+      -rc_name   => 'default',
+      -flow_into => { 1 => ['prepare_uniprot_files'] },
+    },
+
+    {
+      -logic_name => 'prepare_uniprot_files',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd => 'sh '.$self->o('prepare_uniprot_script').' '.$self->o('uniprot_dir').' #output_dir#'
+                     },
+      -rc_name   => 'default',
+      -flow_into => { 1 => ['prepare_uniprot_files_indexes'] },
+    },
+
+    {
+      -logic_name => 'prepare_uniprot_files_indexes',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd =>
+                               'perl '.$self->o('prepare_uniprot_index_script').
+                               ' -uniprot_sp_file #uniprot_sp_file#'.
+                               ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
+                               ' -uniprot_tr_dir #uniprot_tr_dir#'
+                     },
+      -rc_name   => 'default_35GB',
+      -flow_into => { 1 => ['insert_alignment_run_id_for_perfect'] },
+    },
+
+    {
+      -logic_name => 'insert_alignment_run_id_for_perfect',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd =>
+                               'RELEASEMAPPINGHISTORYID='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".release_mapping_history_id");'.
+
+                               'PERFECTMATCHALIGNMENTRUNID='.
+                               '$(wget -O - -o /dev/null --post-data="$(jq -n -r --arg rmh "$RELEASEMAPPINGHISTORYID" \'{ '.
+                                 'score1_type: "perfect_match", '.
+                                 'score2_type: "sp mapping ONE2ONE", '.
+                                 'pipeline_name: "'.$self->o('pipeline_name').'", '.
+                                 'pipeline_comment: "'.$self->o('pipeline_comment_perfect_match').'", '.
+                                 'pipeline_script: "GIFTS/scripts/eu_alignment_perfect_match.pl", '.
+                                 'userstamp: "'.$self->o('userstamp').'", '.
+                                 'release_mapping_history: $rmh, '.
+                                 'logfile_dir: "#output_dir#", '.
+                                 'uniprot_file_swissprot: "#uniprot_sp_file#", '.
+                                 'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
+                                 'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
+                                 'ensembl_release: '.$self->o('ensembl_release').' }\')'.
+                               '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
+                               ' | jq -r \'.alignment_run_id\');'. # wget should return a json containing the alignment_run_id created
+                               
+                               'echo $PERFECTMATCHALIGNMENTRUNID > #output_dir#/#perfect_alignment_run_id_file#'
+                     },
+      -rc_name   => 'default',
+      -flow_into => { 1 => ['make_perfect_mapping_input_ids'] },
+    },
+
+    {
+      -logic_name => 'make_perfect_mapping_input_ids',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -parameters => {
+                        inputcmd =>
+
+                        'RELEASEMAPPINGHISTORYID='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".release_mapping_history_id");'.
+
+                        'NUMMAPPINGS=$(wget -O - -o /dev/null '.
+                        $self->o('mappings_by_release_mapping_history_url').'$RELEASEMAPPINGHISTORYID'.
+                          ' | jq -r ".count");'.
+                        
+                        'for PAGENUM in $(seq 1 $(((NUMMAPPINGS+9)/10)));'. # (NUMMAPPINGS+9/10 is the number of pages of 10 elements returned by the REST API 
+                        'do '.
+                          'echo $PAGENUM;'.
+                        'done',
+
+                        column_names => ['page'],
+                        step => 200,
+                     },
+      -flow_into  => { '2->A' => [ 'perfect_match_alignments' ],
+                      'A->1' => [ 'insert_alignment_run_id_for_blast' ]}
+    },
+
+    {
+      -logic_name => 'perfect_match_alignments',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd =>
+                               'RELEASEMAPPINGHISTORYID='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".release_mapping_history_id");'.
+                               
+                               'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #output_dir#/#perfect_alignment_run_id_file# | awk \'{print $1}\');'.
+                               
+                               'perl '.$self->o('perfect_match_script').
+                               ' -output_dir #output_dir#'.
+                               ' -registry_host '.$self->o('registry_host').
+                               ' -registry_user '.$self->o('registry_user').
+                               ' -registry_port '.$self->o('registry_port').
+                               ' -user '.$self->o('userstamp').
+                               ' -species #species#'.
+                               ' -release '.$self->o('ensembl_release').
+                               ' -release_mapping_history_id $RELEASEMAPPINGHISTORYID'.
+                               ' -uniprot_sp_file #uniprot_sp_file#'.
+                               ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
+                               ' -uniprot_tr_dir #uniprot_tr_dir#'.
+                               ' -pipeline_name '.$self->o('pipeline_name').
+                               ' -pipeline_comment "'.$self->o('pipeline_comment_perfect_match').'"'.
+                               ' -rest_server '.$self->o('rest_server').
+                               ' -alignment_run_id $PERFECTMATCHALIGNMENTRUNID'.
+                               ' -page "#expr(join(",",@{#_range_list#}))expr#"'
+                     },
+      -rc_name    => 'default_35GB',
+      -analysis_capacity => 50,
+    },
+
+    {
+      -logic_name => 'insert_alignment_run_id_for_blast',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd =>
+                               'RELEASEMAPPINGHISTORYID='.
+                               '$(wget -O - -o /dev/null '.
+                               $self->o('latest_release_mapping_history_url').'#assembly#/'.
+                               ' | jq -r ".release_mapping_history_id");'.
+
+                               'wget -O - -o /dev/null --post-data="$(jq -n -r --arg rmh "$RELEASEMAPPINGHISTORYID" \'{ '.
+                                 'score1_type: "identity", '.
+                                 'score2_type: "coverage", '.
+                                 'pipeline_name: "'.$self->o('pipeline_name').'", '.
+                                 'pipeline_comment: "'.$self->o('pipeline_comment_blast_cigar').'", '.
+                                 'pipeline_script: "GIFTS/scripts/eu_alignment_blast_cigar.pl", '.
+                                 'userstamp: "'.$self->o('userstamp').'", '.
+                                 'release_mapping_history: $rmh, '.
+                                 'logfile_dir: "#output_dir#", '.
+                                 'uniprot_file_swissprot: "#uniprot_sp_file#", '.
+                                 'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
+                                 'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
+                                 'ensembl_release: '.$self->o('ensembl_release').' }\')'.
+                               '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
+                               ' | jq -r \'.alignment_run_id\''. # wget should return a json containing the alignment_run_id created
+                               
+                               ' > #output_dir#/#blast_alignment_run_id_file#'
+                     },
+      -rc_name    => 'default',
+      -flow_into  => { 1 => ['make_blast_mapping_input_ids'] },
+      -analysis_capacity => 125,
+    },
+
+    {
+      -logic_name => 'make_blast_mapping_input_ids',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -parameters => {
+                        inputcmd =>
+
+                        'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #output_dir#/#perfect_alignment_run_id_file# | awk \'{print $1}\');'.
+                        'NUMALIGNMENTS=$(wget -O - -o /dev/null '.
+                        $self->o('alignments_by_alignment_run_url').'$PERFECTMATCHALIGNMENTRUNID'. # alignment_type parameter by default is "perfect_match"
+                          ' | jq -r ".count");'.
+
+                        'for PAGENUM in $(seq 1 $(((NUMALIGNMENTS+9)/10)));'. # (NUMALIGNMENTS+9/10 is the number of pages of 10 elements returned by the REST API 
+                        'do '.
+                          'wget -O - -o /dev/null '.
+                        $self->o('alignments_by_alignment_run_url').'$PERFECTMATCHALIGNMENTRUNID/?page=$PAGENUM'.
+                          ' | jq -r ".results[] | select(.score1 == 0)"'.
+                          ' | jq -r ".mapping";'.
+                        'done',
+
+                        column_names => ['mapping_id'],
+                        step => 100,
       },
+      -flow_into => { '2->A' => [ 'blast_cigar_alignments' ],
+                      'A->1' => [ 'set_alignment_completed' ]}
+    },
 
-      {
-        -logic_name => 'prepare_uniprot_files',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'sh '.$self->o('prepare_uniprot_script').' '.$self->o('uniprot_dir').' #output_dir#'
-                       },
-        -rc_name          => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['prepare_uniprot_files_indexes'] },
-      },
+    {
+      -logic_name => 'blast_cigar_alignments',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd =>
+                               'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #output_dir#/#perfect_alignment_run_id_file# | awk \'{print $1}\');'.
 
-      {
-        -logic_name => 'prepare_uniprot_files_indexes',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'perl '.$self->o('prepare_uniprot_index_script').
-                                 ' -uniprot_sp_file #uniprot_sp_file#'.
-                                 ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
-                                 ' -uniprot_tr_dir #uniprot_tr_dir#'
-                       },
-        -rc_name    => 'default_35GB',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['insert_alignment_run_id_for_perfect'] },
-      },
+                               'ALIGNMENTRUNID=$(head -n1 #output_dir#/#blast_alignment_run_id_file# | awk \'{print $1}\');'.
 
-      {
-        -logic_name => 'insert_alignment_run_id_for_perfect',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".release_mapping_history_id");'.
+                               'perl '.$self->o('blast_cigar_script').
+                               ' -user '.$self->o('userstamp').
+                               ' -species #species#'.
+                               ' -perfect_match_alignment_run_id $PERFECTMATCHALIGNMENTRUNID'.
+                               ' -registry_host '.$self->o('registry_host').
+                               ' -registry_user '.$self->o('registry_user').
+                               ' -registry_port '.$self->o('registry_port').
+                               ' -pipeline_name '.$self->o('pipeline_name').
+                               ' -pipeline_comment "'.$self->o('pipeline_comment_blast_cigar').'"'.
+                               ' -rest_server '.$self->o('rest_server').
+                               ' -output_dir #output_dir#'.
+                               ' -alignment_run_id $ALIGNMENTRUNID'.
+                               ' -mapping_id "#expr(join(",",@{#_range_list#}))expr#"'
+                     },
+      -rc_name    => 'default_35GB',
+      -analysis_capacity => 40,
+    },
+    
+    {
+      -logic_name => 'set_alignment_completed',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #output_dir#/#import_species_data_file#'.
+                               ' | awk \'{print $3}\');'.
 
-                                 'PERFECTMATCHALIGNMENTRUNID='.
-                                 '$(wget -O - -o /dev/null --post-data="$(jq -n -r --arg rmh "$RELEASEMAPPINGHISTORYID" \'{ '.
-                                   'score1_type: "perfect_match", '.
-                                   'score2_type: "sp mapping ONE2ONE", '.
-                                   'pipeline_name: "'.$self->o('pipeline_name').'", '.
-                                   'pipeline_comment: "'.$self->o('pipeline_comment_perfect_match').'", '.
-                                   'pipeline_script: "GIFTS/scripts/eu_alignment_perfect_match.pl", '.
-                                   'userstamp: "'.$self->o('userstamp').'", '.
-                                   'release_mapping_history: $rmh, '.
-                                   'logfile_dir: "#output_dir#", '.
-                                   'uniprot_file_swissprot: "#uniprot_sp_file#", '.
-                                   'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
-                                   'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                   'ensembl_release: '.$self->o('release').' }\')'.
-                                 '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
-                                 ' | jq -r \'.alignment_run_id\');'. # wget should return a json containing the alignment_run_id created
-                                 
-                                 'echo $PERFECTMATCHALIGNMENTRUNID > #perfect_alignment_run_id_output_file#'
-                       },
-        -rc_name    => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['make_perfect_mapping_input_ids'] },
-      },
+                               'wget -O- --post-data="" '.
+                               '--header=Content-Type:application/json '.
+                               $self->o('set_alignment_status_url').
+                               '$ENSEMBLSPECIESHISTORYID/alignment_status/ALIGNMENT_COMPLETED/ '
+                     },
+      -rc_name    => 'default',
+    },
+    
+    {
+      -logic_name => 'notify',
+      -module     => 'Bio::EnsEMBL::GIFTS::Notify',
+      -rc_name    => 'default',
+      -flow_into  => {
+                       '1' => ['?table_name=result'],
+                     },
+    },
 
-      {
-        -logic_name => 'make_perfect_mapping_input_ids',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-        -parameters => {
-                          inputcmd =>
-
-                          'RELEASEMAPPINGHISTORYID='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".release_mapping_history_id");'.
-
-                          'NUMMAPPINGS=$(wget -O - -o /dev/null '.
-                          $self->o('mappings_by_release_mapping_history_url').'$RELEASEMAPPINGHISTORYID'.
-                            ' | jq -r ".count");'.
-                          
-                          'for PAGENUM in $(seq 1 $(((NUMMAPPINGS+9)/10)));'. # (NUMMAPPINGS+9/10 is the number of pages of 10 elements returned by the REST API 
-                          'do '.
-                            'echo $PAGENUM;'.
-                          'done',
-
-                          column_names => ['page'],
-                          step => 200,
-        },
-        -max_retry_count => 0,
-        -flow_into => { '2->A' => [ 'perfect_match_alignments' ],
-                        'A->1' => [ 'insert_alignment_run_id_for_blast' ]}
-      },
-
-      {
-        -logic_name => 'perfect_match_alignments',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".release_mapping_history_id");'.
-                                 
-                                 'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #perfect_alignment_run_id_output_file# | awk \'{print $1}\');'.
-                                 
-                                 'perl '.$self->o('perfect_match_script').
-                                 ' -output_dir #output_dir#'.
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -species #species#'.
-                                 ' -release '.$self->o('release').
-                                 ' -release_mapping_history_id $RELEASEMAPPINGHISTORYID'.
-                                 ' -uniprot_sp_file #uniprot_sp_file#'.
-                                 ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
-                                 ' -uniprot_tr_dir #uniprot_tr_dir#'.
-                                 ' -pipeline_name '.$self->o('pipeline_name').
-                                 ' -pipeline_comment "'.$self->o('pipeline_comment_perfect_match').'"'.
-                                 ' -rest_server '.$self->o('rest_server').
-                                 ' -alignment_run_id $PERFECTMATCHALIGNMENTRUNID'.
-                                 ' -page "#expr(join(",",@{#_range_list#}))expr#"'
-                       },
-        -rc_name    => 'default_35GB',
-
-        -max_retry_count => 0,
-        -analysis_capacity => 50,
-      },
-
-      {
-        -logic_name => 'insert_alignment_run_id_for_blast',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(wget -O - -o /dev/null '.
-                                 $self->o('latest_release_mapping_history_url').'#assembly#/'.
-                                 ' | jq -r ".release_mapping_history_id");'.
-
-                                 'wget -O - -o /dev/null --post-data="$(jq -n -r --arg rmh "$RELEASEMAPPINGHISTORYID" \'{ '.
-                                   'score1_type: "identity", '.
-                                   'score2_type: "coverage", '.
-                                   'pipeline_name: "'.$self->o('pipeline_name').'", '.
-                                   'pipeline_comment: "'.$self->o('pipeline_comment_blast_cigar').'", '.
-                                   'pipeline_script: "GIFTS/scripts/eu_alignment_blast_cigar.pl", '.
-                                   'userstamp: "'.$self->o('userstamp').'", '.
-                                   'release_mapping_history: $rmh, '.
-                                   'logfile_dir: "#output_dir#", '.
-                                   'uniprot_file_swissprot: "#uniprot_sp_file#", '.
-                                   'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
-                                   'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                   'ensembl_release: '.$self->o('release').' }\')'.
-                                 '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
-                                 ' | jq -r \'.alignment_run_id\''. # wget should return a json containing the alignment_run_id created
-                                 
-                                 ' > #blast_alignment_run_id_output_file#'
-                       },
-        -rc_name    => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['make_blast_mapping_input_ids'] },
-        -analysis_capacity => 125,
-      },
-
-      {
-        -logic_name => 'make_blast_mapping_input_ids',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-        -parameters => {
-                          inputcmd =>
-
-                          'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #perfect_alignment_run_id_output_file# | awk \'{print $1}\');'.
-                          'NUMALIGNMENTS=$(wget -O - -o /dev/null '.
-                          $self->o('alignments_by_alignment_run_url').'$PERFECTMATCHALIGNMENTRUNID'. # alignment_type parameter by default is "perfect_match"
-                            ' | jq -r ".count");'.
-
-                          'for PAGENUM in $(seq 1 $(((NUMALIGNMENTS+9)/10)));'. # (NUMALIGNMENTS+9/10 is the number of pages of 10 elements returned by the REST API 
-                          'do '.
-                            'wget -O - -o /dev/null '.
-                          $self->o('alignments_by_alignment_run_url').'$PERFECTMATCHALIGNMENTRUNID/?page=$PAGENUM'.
-                            ' | jq -r ".results[] | select(.score1 == 0)"'.
-                            ' | jq -r ".mapping";'.
-                          'done',
-
-                          column_names => ['mapping_id'],
-                          step => 100,
-        },
-        -flow_into => { '2->A' => [ 'blast_cigar_alignments' ],
-                        'A->1' => [ 'set_alignment_completed' ]}
-      },
-
-      {
-        -logic_name => 'blast_cigar_alignments',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'PERFECTMATCHALIGNMENTRUNID=$(head -n1 #perfect_alignment_run_id_output_file# | awk \'{print $1}\');'.
-
-                                 'ALIGNMENTRUNID=$(head -n1 #blast_alignment_run_id_output_file# | awk \'{print $1}\');'.
-
-                                 'perl '.$self->o('blast_cigar_script').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -species #species#'.
-                                 ' -perfect_match_alignment_run_id $PERFECTMATCHALIGNMENTRUNID'.
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -pipeline_name '.$self->o('pipeline_name').
-                                 ' -pipeline_comment "'.$self->o('pipeline_comment_blast_cigar').'"'.
-                                 ' -rest_server '.$self->o('rest_server').
-                                 ' -output_dir #output_dir#'.
-                                 ' -alignment_run_id $ALIGNMENTRUNID'.
-                                 ' -mapping_id "#expr(join(",",@{#_range_list#}))expr#"'
-                       },
-        -rc_name    => 'default_35GB',
-        -max_retry_count => 0,
-        -analysis_capacity => 40,
-      },
-      
-      {
-        -logic_name => 'set_alignment_completed',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #import_species_data_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-
-                                 'wget -O- --post-data="" '.
-                                 '--header=Content-Type:application/json '.
-                                 $self->o('set_alignment_status_url').
-                                 '$ENSEMBLSPECIESHISTORYID/alignment_status/ALIGNMENT_COMPLETED/ '
-                       },
-        -rc_name    => 'default',
-        -max_retry_count => 0,
-      },
-    ];
-  }
-
-sub hive_meta_table {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::hive_meta_table},       # here we inherit anything from the base class
-        'hive_use_param_stack'  => 1,           # switch on the new param_stack mechanism
-    };
+  ];
 }
-
-sub pipeline_wide_parameters {
-    my ($self) = @_;
-
-    return {
-	    %{ $self->SUPER::pipeline_wide_parameters() },  # inherit other stuff from the base class
-    };
-  }
-
-sub resource_classes {
-    my $self = shift;
-    return {
-      'default' => { LSF => '-M1900 -R"select[mem>1900] rusage[mem=1900]"' },
-      'default_35GB' => { LSF => '-M35000 -R"select[mem>35000] rusage[mem=35000]"' },
-    }
-  }
 
 1;

--- a/HiveLoadGIFTS_alignments_conf.pm
+++ b/HiveLoadGIFTS_alignments_conf.pm
@@ -21,7 +21,7 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
- Export Ensembl genes from core databases.
+ Alignment of Ensembl and UniProt data.
  
  Mandatory parameters without default values:
   -registry_host    mysql server with core databases

--- a/HiveLoadGIFTS_conf.pm
+++ b/HiveLoadGIFTS_conf.pm
@@ -22,410 +22,94 @@ package HiveLoadGIFTS_conf;
 use warnings;
 use strict;
 use feature 'say';
-use File::Spec::Functions;
 
-use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
-use base ('Bio::EnsEMBL::Analysis::Hive::Config::HiveBaseConfig_conf');
-
-use Bio::EnsEMBL::ApiVersion qw/software_version/;
+use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
 
 sub default_options {
   my ($self) = @_;
   return {
-    # inherit other stuff from the base class
-	  %{ $self->SUPER::default_options() },
+    %{$self->SUPER::default_options},
 
-'enscode_root_dir' => '/path/to/enscode/',
+    # Username to be registered as the one loading the Ensembl data
+    userstamp => 'ensembl_gifts_loading_pipeline',
 
-'release' => ,              # Ensembl release number corresponding to the species gene sets to be imported
-'registry_host' => '',      # Ensembl databases server
-'registry_port' => '',      # Ensembl databases port
-'registry_user' => '',      # Ensembl databases read-only user
-'registry_pass' => '',      # Ensembl databases read-only password
+    # In order to seed the database multiple times, we need the
+    # species list here, rather than specified via 'input_id'.
+    species_list => [
+      {
+        assembly   => 'GRCh38',
+        species    => 'homo_sapiens',
+      },
+      {
+        assembly => 'GRCm38',
+        species  => 'mus_musculus',
+      }
+    ],
 
-# GIFTS database details including read-only (r) and write (w) credentials
-'giftsdb_host' => '',
-'giftsdb_r_user' => '',
-'giftsdb_r_pass' => '',
-'giftsdb_w_user' => '',
-'giftsdb_w_pass' => '',
-'giftsdb_name' => '',
-'giftsdb_schema' => '',
-'giftsdb_port' => '',
+    # Parameters to track submissions
+    tag       => undef,
+    timestamp => undef,
+    email     => undef,
 
-'uniprot_dir' => '/path/to/uniprot/knowledgebase/', # path where the UniProt fasta files are stored
+    # Switch off automatic retries
+    hive_default_max_retry_count => 0,
 
-# database details for the eHive pipe database
-'server1' => '',
-'port1' => '',
-'user_w' => '',      # write user for the pipeline db
-'password' => '',    # write password for the pipeline db
-'driver' => 'mysql', # driver for the pipeline db
-
-# no need to modify anything below this line EXCEPT FOR the 'output_dir' in the 'input_ids' section 
-'userstamp' => 'ensembl_gifts_loading_pipeline', # username to be registered as the one loading the Ensembl data
-'pipeline_name' => 'gifts_loading',
-'pipeline_dbname' => $self->o('pipeline_name'), # this db will be created
-
-'pipeline_comment_perfect_match' => 'Perfect matches between Ensembl and UniProt proteins.',
-'pipeline_comment_blast_cigar' => 'Blasts and cigars between Ensembl and UniProt proteins.',
-
-'pipeline_db' => {
-                    -dbname => $self->o('pipeline_dbname'),
-                    -host   => $self->o('server1'),
-                    -port   => $self->o('port1'),
-                    -user   => $self->o('user_w'),
-                    -pass   => $self->o('password'),
-                    -driver => $self->o('driver'),
-                 },
   };
+}
+
+# Implicit parameter propagation throughout the pipeline.
+sub hive_meta_table {
+  my ($self) = @_;
   
-'import_species_script'  => $self->o('enscode_root_dir').'/GIFTS/scripts/ensembl_import_species_data.pl', # no need to modify this
-'prepare_uniprot_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/uniprot_fasta_prep.sh',          # no need to modify this
-'perfect_match_script'   => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_perfect_match.pl',  # no need to modify this
-'blast_cigar_script'     => $self->o('enscode_root_dir').'/GIFTS/scripts/eu_alignment_blast_cigar.pl',    # no need to modify this
-  
+  return {
+    %{$self->SUPER::hive_meta_table},
+    'hive_use_param_stack' => 1,
+  };
 }
 
 sub pipeline_create_commands {
-    my ($self) = @_;
-    return [
-      # inheriting database and hive tables' creation
-	    @{$self->SUPER::pipeline_create_commands},
-    ];
-  }
+  my ($self) = @_;
 
+  my $submission_table_sql = q/
+    CREATE TABLE gifts_submission (
+      job_id INT PRIMARY KEY,
+      tag VARCHAR(255) NULL,
+      email VARCHAR(255) NULL,
+      submitted VARCHAR(255) NULL
+    );
+  /;
 
-## See diagram for pipeline structure
-sub pipeline_analyses {
-    my ($self) = @_;
+  my $result_table_sql = q/
+    CREATE TABLE result (
+      job_id INT PRIMARY KEY,
+      output TEXT
+    );
+  /;
 
-    return [
-      {
-        -input_ids  => [
-                         {
-                            species => 'homo_sapiens',
-                            output_dir => '/path/to/GIFTS_#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                            'perfect_match_alignments_output_file' => '#output_dir#/perfect_match_alignments.out',
-                            'alignment_run_id_output_file' => '#output_dir#/alignment_run_id.out',
+  my $drop_input_id_index = q/
+    ALTER TABLE job DROP KEY input_id_stacks_analysis;
+  /;
 
-                            # these files will be created during the 'prepare_uniprot_files' analysis
-                            # from the uniprot_dir files above and they will be used by the perfect match alignment script
-                            'uniprot_sp_file' => '#output_dir#/uniprot_sp.cleaned.fa.gz',
-                            'uniprot_sp_isoform_file' => '#output_dir#/uniprot_sp_isoforms.cleaned.fa.gz',
-                            'uniprot_tr_dir' => '#output_dir#/trembl20/',
-                         },
-                         {
-                            species => 'mus_musculus',
-                            output_dir => '/path/to/GIFTS_#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                            'perfect_match_alignments_output_file' => '#output_dir#/perfect_match_alignments.out',
-                            'alignment_run_id_output_file' => '#output_dir#/alignment_run_id.out',
+  my $extend_input_id = q/
+    ALTER TABLE job MODIFY input_id TEXT;
+  /;
 
-                            # these files will be created during the 'prepare_uniprot_files' analysis
-                            # from the uniprot_dir files above and they will be used by the perfect match alignment script
-                            'uniprot_sp_file' => '#output_dir#/uniprot_sp.cleaned.fa.gz',
-                            'uniprot_sp_isoform_file' => '#output_dir#/uniprot_sp_isoforms.cleaned.fa.gz',
-                            'uniprot_tr_dir' => '#output_dir#/trembl20/',
-                         }
-        ],
-
-        -logic_name => 'import_species_data',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'mkdir -p #output_dir#;'.
-                                 'perl '.$self->o('import_species_script').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -species #species#'.
-                                 ' -release '.$self->o('release').
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -giftsdb_host '.$self->o('giftsdb_host').
-                                 ' -giftsdb_user '.$self->o('giftsdb_w_user').
-                                 ' -giftsdb_pass '.$self->o('giftsdb_w_pass').
-                                 ' -giftsdb_name '.$self->o('giftsdb_name').
-                                 ' -giftsdb_schema '.$self->o('giftsdb_schema').
-                                 ' -giftsdb_port '.$self->o('giftsdb_port').
-                                 ' > #import_species_data_output_file#'
-                       },
-        -rc_name    => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['wait_for_uniprot_mappings'] },
-      },
-
-      # Loop for 7 days maximum to detect if the UniProt mappings have been loaded into
-      # the GIFTS database for the given ensembl_species_history_id.
-      {
-        -logic_name => 'wait_for_uniprot_mappings',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          # 7 days (604800s) max checking every 10 minutes (600s)
-                          cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #import_species_data_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-                                 'end=$((SECONDS+604800));'.
-                                 'while [[ ( $SECONDS -lt $end ) && ( $RELEASEMAPPINGHISTORYID -eq "0" ) ]]; do '.
-                                 
-                                 'echo "Fetching release_mapping_history_id for ensembl_species_history_id $ENSEMBLSPECIESHISTORYID ...";'.
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(PGPASSWORD='.$self->o('giftsdb_r_pass').
-                                 ' psql -h '.$self->o('giftsdb_host').
-                                 '      -p '.$self->o('giftsdb_port').
-                                 '      -d '.$self->o('giftsdb_name').
-                                 '      -U '.$self->o('giftsdb_r_user').
-                                 '   -t -c "SET search_path TO '.$self->o('giftsdb_schema').'; '.
-                                 '          SELECT release_mapping_history_id '.
-                                 '          FROM release_mapping_history '.
-                                 '          WHERE release_mapping_history_id NOT IN (SELECT release_mapping_history_id '.
-                                 '                                                   FROM alignment_run) '.
-                                 '                AND ensembl_species_history_id=$ENSEMBLSPECIESHISTORYID'.
-                                 '                AND status=\'MAPPING_COMPLETED\''.
-                                 '          ORDER BY time_mapped DESC LIMIT 1;'.
-                                 '         ");'.
-
-                                 'sleep 600;'.
-                                 'done;'.
-                                 'if [ $RELEASEMAPPINGHISTORYID -eq "0" ]; then exit -1;fi'
-                       },
-        -rc_name          => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['prepare_uniprot_files'] },
-      },
-
-      {
-        -logic_name => 'prepare_uniprot_files',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'sh '.$self->o('prepare_uniprot_script').' '.$self->o('uniprot_dir').' #output_dir#'
-                       },
-        -rc_name          => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['perfect_match_alignments'] },
-      },
-
-      {
-        -logic_name => 'perfect_match_alignments',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #import_species_data_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-                                 
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(PGPASSWORD='.$self->o('giftsdb_r_pass').
-                                 ' psql -h '.$self->o('giftsdb_host').
-                                 '      -p '.$self->o('giftsdb_port').
-                                 '      -d '.$self->o('giftsdb_name').
-                                 '      -U '.$self->o('giftsdb_r_user').
-                                 '   -t -c "SET search_path TO '.$self->o('giftsdb_schema').'; '.
-                                 '          SELECT release_mapping_history_id '.
-                                 '          FROM release_mapping_history '.
-                                 '          WHERE release_mapping_history_id NOT IN (SELECT release_mapping_history_id '.
-                                 '                                                   FROM alignment_run) '.
-                                 '                AND ensembl_species_history_id=$ENSEMBLSPECIESHISTORYID'.
-                                 '                AND status=\'MAPPING_COMPLETED\''.
-                                 '          ORDER BY time_mapped DESC LIMIT 1;'.
-                                 '         ");'.
-                                 
-                                 'perl '.$self->o('perfect_match_script').
-                                 ' -output_dir #output_dir#'.
-                                 ' -giftsdb_host '.$self->o('giftsdb_host').
-                                 ' -giftsdb_user '.$self->o('giftsdb_w_user').
-                                 ' -giftsdb_pass '.$self->o('giftsdb_w_pass').
-                                 ' -giftsdb_name '.$self->o('giftsdb_name').
-                                 ' -giftsdb_schema '.$self->o('giftsdb_schema').
-                                 ' -giftsdb_port '.$self->o('giftsdb_port').
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -species #species#'.
-                                 ' -release '.$self->o('release').
-                                 ' -release_mapping_history_id $RELEASEMAPPINGHISTORYID'.
-                                 ' -uniprot_sp_file #uniprot_sp_file#'.
-                                 ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
-                                 ' -uniprot_tr_dir #uniprot_tr_dir#'.
-                                 ' -pipeline_name '.$self->o('pipeline_name').
-                                 ' -pipeline_comment '.$self->o('pipeline_comment_perfect_match').
-                                 ' > #perfect_match_alignments_output_file#'
-                       },
-        -rc_name    => 'default_30GB',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['insert_alignment_run_id'] },
-      },
-
-      {
-        -logic_name => 'insert_alignment_run_id_for_blast',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'ENSEMBLSPECIESHISTORYID=$(grep "Added ensembl_species_history_id" #import_species_data_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-
-                                 'PERFECTMATCHALIGNMENTRUNID=$(grep "Alignment run" #perfect_match_alignments_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-
-                                 'RELEASEMAPPINGHISTORYID='.
-                                 '$(PGPASSWORD='.$self->o('giftsdb_r_pass').
-                                 ' psql -h '.$self->o('giftsdb_host').
-                                 '      -p '.$self->o('giftsdb_port').
-                                 '      -d '.$self->o('giftsdb_name').
-                                 '      -U '.$self->o('giftsdb_r_user').
-                                 '   -t -c "SET search_path TO '.$self->o('giftsdb_schema').'; '.
-                                 '          SELECT release_mapping_history_id '.
-                                 '          FROM alignment_run '.
-                                 '          WHERE alignment_run_id=$PERFECTMATCHALIGNMENTRUNID;'.
-                                 '         "'.
-                                 ' );'.
-
-                                 'PGPASSWORD='.$self->o('giftsdb_w_pass').
-                                 ' psql -h '.$self->o('giftsdb_host').
-                                 '      -p '.$self->o('giftsdb_port').
-                                 '      -d '.$self->o('giftsdb_name').
-                                 '      -U '.$self->o('giftsdb_w_user').
-                                 '   -t -c "SET search_path TO '.$self->o('giftsdb_schema').'; '.
-                                 '          INSERT INTO alignment_run '.
-                                 '          (score1_type,'.
-                                 '           score2_type,'.
-                                 '           pipeline_name,'.
-                                 '           pipeline_comment,'.
-                                 '           pipeline_script,'.
-                                 '           userstamp,'.
-                                 '           release_mapping_history_id,'.
-                                 '           logfile_dir,'.
-                                 '           uniprot_file_swissprot,'.
-                                 '           uniprot_file_isoform,'.
-                                 '           uniprot_dir_trembl,'.
-                                 '           ensembl_release)'.
-                                 '          VALUES('.
-                                 '           \'identity\','.
-                                 '           \'coverage\','.
-                                 '           \''.$self->o('pipeline_name').'\','.
-                                 '           \''.$self->o('pipeline_comment_blast_cigar').'\','.
-                                 '           \'GIFTS/scripts/eu_alignment_blast_cigar.pl\','.                                 
-                                 '           \''.$self->o('userstamp').'\','.
-                                 '           $RELEASEMAPPINGHISTORYID ,'.
-                                 '           \'#output_dir#\','.
-                                 '           \'#uniprot_sp_file#\','.
-                                 '           \'#uniprot_sp_isoform_file#\','.
-                                 '           \'#uniprot_tr_dir#\','.
-                                             $self->o('release').'); '.
-                                 '          SELECT lastval() FROM alignment_run;"'.
-                                 ' > #alignment_run_id_output_file#'
-                       },
-        -rc_name    => 'default',
-        -max_retry_count => 0,
-        -flow_into => { 1 => ['make_mapping_input_ids'] },
-      },
-
-      {
-        -logic_name => 'make_mapping_input_ids',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-        -parameters => {
-                          inputcmd =>
-                           
-                          'PERFECTMATCHALIGNMENTRUNID=$(grep "Alignment run" #perfect_match_alignments_output_file#'.
-                          ' | awk \'{print $3}\');'.
- 
-                          ' PGPASSWORD='.$self->o('giftsdb_r_pass').
-                          ' psql -h '.$self->o('giftsdb_host').
-                          '      -p '.$self->o('giftsdb_port').
-                          '      -d '.$self->o('giftsdb_name').
-                          '      -U '.$self->o('giftsdb_r_user').
-                          '   -t -c "SET search_path TO '.$self->o('giftsdb_schema').'; '.
-                          '          SELECT mapping_id '.
-                          '          FROM alignment '.
-                          '          WHERE alignment_run_id=$PERFECTMATCHALIGNMENTRUNID'.
-                          '            AND score1=0;"',
-                           
-                          column_names => ['mapping_id'],
-                          step => 100,
-        },
-        -flow_into => { '2->A' => [ 'blast_cigar_alignments' ],
-                        'A->1' => [ 'dummy' ]}
-      },
-
-      {
-        -logic_name => 'blast_cigar_alignments',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd =>
-                                 'PERFECTMATCHALIGNMENTRUNID=$(grep "Alignment run" #perfect_match_alignments_output_file#'.
-                                 ' | awk \'{print $3}\');'.
-
-                                 'ALIGNMENTRUNID=$(head -n1 #alignment_run_id_output_file# | awk \'{print $1}\');'.
-
-                                 'perl '.$self->o('blast_cigar_script').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -perfect_match_alignment_run_id $PERFECTMATCHALIGNMENTRUNID'.
-                                 ' -giftsdb_host '.$self->o('giftsdb_host').
-                                 ' -giftsdb_user '.$self->o('giftsdb_w_user').
-                                 ' -giftsdb_pass '.$self->o('giftsdb_w_pass').
-                                 ' -giftsdb_name '.$self->o('giftsdb_name').
-                                 ' -giftsdb_schema '.$self->o('giftsdb_schema').
-                                 ' -giftsdb_port '.$self->o('giftsdb_port').
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -pipeline_name '.$self->o('pipeline_name').
-                                 ' -pipeline_comment "'.$self->o('pipeline_comment_blast_cigar').'"'.
-                                 ' -output_dir #output_dir#'.
-                                 ' -alignment_run_id $ALIGNMENTRUNID'.
-                                 ' -mapping_id "#expr(join(",",@{#_range_list#}))expr#"'
-                       },
-        -rc_name    => 'default_18GB',
-        -max_retry_count => 0,
-        -analysis_capacity => 50,
-      },
-
-      {
-        -logic_name => 'dummy',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-        -parameters => {},
-        -rc_name       => 'default',
-        -can_be_empty  => 1,
-      },      
-      
-    ];
-  }
-
-sub hive_meta_table {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::hive_meta_table},       # here we inherit anything from the base class
-        'hive_use_param_stack'  => 1,           # switch on the new param_stack mechanism
-    };
+  return [
+    @{$self->SUPER::pipeline_create_commands},
+    $self->db_cmd($submission_table_sql),
+    $self->db_cmd($result_table_sql),
+    $self->db_cmd($drop_input_id_index),
+    $self->db_cmd($extend_input_id),
+  ];
 }
 
-sub pipeline_wide_parameters {
-    my ($self) = @_;
-
-    return {
-	    %{ $self->SUPER::pipeline_wide_parameters() },  # inherit other stuff from the base class
-    };
-  }
-
 sub resource_classes {
-    my $self = shift;
-    return {
-      'default' => { LSF => '-M1900 -R"select[mem>1900] rusage[mem=1900]"' },
-      'default_18GB' => { LSF => '-M18000 -R"select[mem>18000] rusage[mem=18000]"' },
-      'default_30GB' => { LSF => '-M30000 -R"select[mem>30000] rusage[mem=30000]"' },
-    }
+  my $self = shift;
+  return {
+    'default'      => { LSF => '-M1900 -R"select[mem>1900] rusage[mem=1900]"' },
+    'default_20GB' => { LSF => '-M20000 -R"select[mem>20000] rusage[mem=20000]"' },
+    'default_35GB' => { LSF => '-M35000 -R"select[mem>35000] rusage[mem=35000]"' },
   }
+}
 
 1;

--- a/HiveLoadGIFTS_genes_conf.pm
+++ b/HiveLoadGIFTS_genes_conf.pm
@@ -15,6 +15,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=head1 NAME
+
+ HiveLoadGIFTS_genes_conf
+
+=head1 DESCRIPTION
+
+ Export Ensembl genes from core databases.
+ 
+ Mandatory parameters without default values:
+  -registry_host    mysql server with core databases
+  -registry_port    mysql port number
+  -registry_user    read-only user
+  -rest_server      GIFTS REST API server URL
+  -base_output_dir  Location of output files
+
 =cut
 
 package HiveLoadGIFTS_genes_conf;
@@ -22,133 +37,83 @@ package HiveLoadGIFTS_genes_conf;
 use warnings;
 use strict;
 use feature 'say';
-use File::Spec::Functions;
 
-use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
-use base ('Bio::EnsEMBL::Analysis::Hive::Config::HiveBaseConfig_conf');
-
-use Bio::EnsEMBL::ApiVersion qw/software_version/;
+use base ('HiveLoadGIFTS_conf');
 
 sub default_options {
   my ($self) = @_;
   return {
-    # inherit other stuff from the base class
-	  %{ $self->SUPER::default_options() },
+    %{$self->SUPER::default_options},
 
-'pipeline_name' => 'gifts_genes_loading',
+    pipeline_name => 'gifts_genes_loading',
 
-'enscode_root_dir' => '/path/to/enscode/',
-'userstamp' => 'ensembl_gifts_loading_pipeline', # username to be registered as the one loading the Ensembl data
-'user_w' => '', # write user for the pipeline db
-'password' => '', # write password for the pipeline db
-'driver' => 'mysql',
-
-'import_species_script' => $self->o('enscode_root_dir').'/GIFTS/scripts/ensembl_import_species_data.pl', # no need to modify this
-
-'rest_server' => '', # GIFTS REST API server URL
-
-'release' => 95, # ensembl release corresponding to the Ensembl gene set in GIFTS to be used
-
-# server containing the Ensembl core databases containing the gene sets to be used
-'registry_host' => '',
-'registry_user' => '', # read-only user 
-'registry_pass' => '', # read-only password
-'registry_port' => '',
-
-# database details for the eHive pipe database
-'server1' => '',
-'port1' => '',
-'pipeline_dbname' => 'USERNAME_'.$self->o('pipeline_name'), # this db will be created
-
-'pipeline_db' => {
-                    -dbname => $self->o('pipeline_dbname'),
-                    -host   => $self->o('server1'),
-                    -port   => $self->o('port1'),
-                    -user   => $self->o('user_w'),
-                    -pass   => $self->o('password'),
-                    -driver => $self->o('driver'),
-                 },
+    enscode_root_dir      => $self->o('ensembl_cvs_root_dir'),
+    import_species_script => $self->o('enscode_root_dir').'/GIFTS/scripts/ensembl_import_species_data.pl',
 
   };
 }
 
-sub pipeline_create_commands {
-    my ($self) = @_;
-    return [
-      # inheriting database and hive tables' creation
-	    @{$self->SUPER::pipeline_create_commands},
-    ];
-  }
-
-
-## See diagram for pipeline structure
-sub pipeline_analyses {
-    my ($self) = @_;
-
-    return [
-      {
-        -input_ids  => [
-                         {
-                            assembly => 'GRCh38',
-                            species => 'homo_sapiens',
-                            output_dir => '/path/to/output_dir/#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                         },
-                         {
-                            assembly => 'GRCm38',
-                            species => 'mus_musculus',
-                            output_dir => '/path/to/output_dir/#species#/',
-                            # output files
-                            'import_species_data_output_file' => '#output_dir#/ensembl_import_species_data.out',
-                         }
-        ],
-
-        -logic_name => 'import_species_data',
-        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-        -parameters => {
-                          use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
-                          use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
-                          cmd => 'mkdir -p #output_dir#;'.
-                                 'perl '.$self->o('import_species_script').
-                                 ' -user '.$self->o('userstamp').
-                                 ' -species #species#'.
-                                 ' -release '.$self->o('release').
-                                 ' -registry_host '.$self->o('registry_host').
-                                 ' -registry_user '.$self->o('registry_user').
-                                 ' -registry_port '.$self->o('registry_port').
-                                 ' -rest_server '.$self->o('rest_server').
-                                 ' > #import_species_data_output_file#'
-                       },
-        -rc_name    => 'default_20GB',
-        -max_retry_count => 0,
-        #-flow_into => { 1 => ['wait_for_uniprot_mappings'] },
-      },
-
-    ];
-  }
-
-sub hive_meta_table {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::hive_meta_table},       # here we inherit anything from the base class
-        'hive_use_param_stack'  => 1,           # switch on the new param_stack mechanism
-    };
+sub pipeline_wide_parameters {
+  my ($self) = @_;
+  
+  return {
+    %{$self->SUPER::pipeline_wide_parameters},
+    'import_species_data_file' => 'ensembl_import_species_data.out',
+  };
 }
 
-sub pipeline_wide_parameters {
-    my ($self) = @_;
+sub pipeline_analyses {
+  my ($self) = @_;
 
-    return {
-	    %{ $self->SUPER::pipeline_wide_parameters() },  # inherit other stuff from the base class
-    };
-  }
+  return [
+    {
+      -logic_name => 'submit',
+      -module     => 'Bio::EnsEMBL::GIFTS::Submit',
+      -parameters => {
+                       species_list    => $self->o('species_list'),
+                       base_output_dir => $self->o('base_output_dir'),
+                       tag             => $self->o('tag'),
+                       timestamp       => $self->o('timestamp'),
+                       email           => $self->o('email'),
+                     },
+      -rc_name    => 'default',
+      -flow_into  => {
+                       '1'    => ['?table_name=gifts_submission'],
+                       '2->A' => ['import_species_data'],
+                       'A->3' => ['notify'],
+                     },
+    },
 
-sub resource_classes {
-    my $self = shift;
-    return {
-      'default_20GB' => { LSF => '-M20000 -R"select[mem>20000] rusage[mem=20000]"' },
-    }
-  }
+    {
+      -logic_name => 'import_species_data',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters => {
+                        use_bash_pipefail => 1, # Boolean. When true, the command will be run with "bash -o pipefail -c $cmd". Useful to capture errors in a command that contains pipes
+                        use_bash_errexit  => 1, # When the command is composed of multiple commands (concatenated with a semi-colon), use "bash -o errexit" so that a failure will interrupt the whole script
+                        cmd => 'mkdir -p #output_dir#;'.
+                               'perl '.$self->o('import_species_script').
+                               ' -user '.$self->o('userstamp').
+                               ' -species #species#'.
+                               ' -release '.$self->o('ensembl_release').
+                               ' -registry_host '.$self->o('registry_host').
+                               ' -registry_user '.$self->o('registry_user').
+                               ' -registry_port '.$self->o('registry_port').
+                               ' -rest_server '.$self->o('rest_server').
+                               ' > #output_dir#/#import_species_data_file#'
+                     },
+      -rc_name    => 'default_20GB',
+    },
+
+    {
+      -logic_name => 'notify',
+      -module     => 'Bio::EnsEMBL::GIFTS::Notify',
+      -rc_name    => 'default',
+      -flow_into  => {
+                       '1' => ['?table_name=result'],
+                     },
+    },
+
+  ];
+}
 
 1;

--- a/modules/Bio/EnsEMBL/GIFTS/Notify.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Notify.pm
@@ -65,7 +65,7 @@ sub set_email_parameters {
     $text    .= "Submission tag: $tag\n";
   }
 
-  $text .= "Output directory: ".$self->param('base_output_dir')."\n";
+  $text .= "Output directory: ".$self->param('base_output_dir')."/".$self->param('release')."\n";
 
   $self->param('subject', $subject);
   $self->param('text', $text);

--- a/modules/Bio/EnsEMBL/GIFTS/Notify.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Notify.pm
@@ -57,6 +57,7 @@ sub set_email_parameters {
   my $subject = "GIFTS pipeline submission completed";
 
   my $text = "Submitted: ".$self->param('submitted')."\n";
+  $text   .= "Ensembl Release: ".$self->param('release')."\n";
 
   my $tag = $self->param('tag');
   if (defined $tag) {

--- a/modules/Bio/EnsEMBL/GIFTS/Notify.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Notify.pm
@@ -1,0 +1,73 @@
+=head1 LICENSE
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::GIFTS::Notify
+
+=head1 DESCRIPTION
+Store result in hive database, and optionally send email notification.
+
+=cut
+
+package Bio::EnsEMBL::GIFTS::Notify;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use JSON;
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
+
+sub run {
+  my $self = shift;
+
+  if ($self->param_is_defined('email')) {
+    $self->set_email_parameters();
+    $self->SUPER::run();
+  }
+}
+
+sub write_output {
+  my $self = shift;
+
+  my $output = {
+    job_id => $self->param('job_id'),
+    output => $self->param('base_output_dir'),
+  };
+
+  $self->dataflow_output_id($output, 1);
+}
+
+sub set_email_parameters {
+  my $self = shift;
+
+  my $subject = "GIFTS pipeline submission completed";
+
+  my $text = "Submitted: ".$self->param('submitted')."\n";
+
+  my $tag = $self->param('tag');
+  if (defined $tag) {
+    $subject .= " ($tag)";
+    $text    .= "Submission tag: $tag\n";
+  }
+
+  $text .= "Output directory: ".$self->param('base_output_dir')."\n";
+
+  $self->param('subject', $subject);
+  $self->param('text', $text);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/GIFTS/Notify.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Notify.pm
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 use feature 'say';
 
-use JSON;
+use File::Spec::Functions qw(catdir);
 
 use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
 
@@ -54,18 +54,23 @@ sub write_output {
 sub set_email_parameters {
   my $self = shift;
 
+  my $tag             = $self->param('tag');
+  my $email           = $self->param('email');
+  my $ensembl_release = $self->param('ensembl_release');
+  my $submitted       = $self->param('submitted');
+  my $base_output_dir = $self->param('base_output_dir');
+
   my $subject = "GIFTS pipeline submission completed";
 
-  my $text = "Submitted: ".$self->param('submitted')."\n";
-  $text   .= "Ensembl Release: ".$self->param('release')."\n";
+  my $text = "Submitted: $submitted\n";
+  $text   .= "Ensembl Release: $ensembl_release\n";
 
-  my $tag = $self->param('tag');
   if (defined $tag) {
     $subject .= " ($tag)";
     $text    .= "Submission tag: $tag\n";
   }
 
-  $text .= "Output directory: ".$self->param('base_output_dir')."/".$self->param('release')."\n";
+  $text .= "Output directory: ".catdir($base_output_dir, $ensembl_release)."\n";
 
   $self->param('subject', $subject);
   $self->param('text', $text);

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -28,7 +28,6 @@ limitations under the License.
   -registry_port    mysql port number
   -registry_user    read-only user
   -uniprot_dir      path to UniProt fasta files
-  -rest_server      GIFTS REST API server URL
   -base_output_dir  Location of output files
 
 =cut

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -93,8 +93,9 @@ sub pipeline_analyses {
                        species_list    => $self->o('species_list'),
                        base_output_dir => $self->o('base_output_dir'),
                        tag             => $self->o('tag'),
-                       timestamp       => $self->o('timestamp'),
                        email           => $self->o('email'),
+                       release         => $self->o('release'),
+                       timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',
       -flow_into  => {

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -94,7 +94,7 @@ sub pipeline_analyses {
                        base_output_dir => $self->o('base_output_dir'),
                        tag             => $self->o('tag'),
                        email           => $self->o('email'),
-                       release         => $self->o('release'),
+                       ensembl_release => $self->o('ensembl_release'),
                        timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',
@@ -196,7 +196,7 @@ sub pipeline_analyses {
                                  'uniprot_file_swissprot: "#uniprot_sp_file#", '.
                                  'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
                                  'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                 'ensembl_release: #release# }\')'.
+                                 'ensembl_release: #ensembl_release# }\')'.
                                '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
                                ' | jq -r \'.alignment_run_id\');'. # wget should return a json containing the alignment_run_id created
                                
@@ -254,7 +254,7 @@ sub pipeline_analyses {
                                ' -registry_port '.$self->o('registry_port').
                                ' -user '.$self->o('userstamp').
                                ' -species #species#'.
-                               ' -release #release#'.
+                               ' -release #ensembl_release#'.
                                ' -release_mapping_history_id $RELEASEMAPPINGHISTORYID'.
                                ' -uniprot_sp_file #uniprot_sp_file#'.
                                ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
@@ -293,7 +293,7 @@ sub pipeline_analyses {
                                  'uniprot_file_swissprot: "#uniprot_sp_file#", '.
                                  'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
                                  'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                 'ensembl_release: #release# }\')'.
+                                 'ensembl_release: #ensembl_release# }\')'.
                                '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
                                ' | jq -r \'.alignment_run_id\''. # wget should return a json containing the alignment_run_id created
                                

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
- HiveLoadGIFTS_alignments_conf;
+ Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_alignments_conf;
 
 =head1 DESCRIPTION
 
@@ -33,13 +33,13 @@ limitations under the License.
 
 =cut
 
-package HiveLoadGIFTS_alignments_conf;
+package Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_alignments_conf;
 
 use warnings;
 use strict;
 use feature 'say';
 
-use base ('HiveLoadGIFTS_conf');
+use base ('Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_conf');
 
 sub default_options {
   my ($self) = @_;

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
     mappings_by_release_mapping_history_url => $self->o('rest_server').'/mappings/release_history/',
     alignment_run_url                       => $self->o('rest_server').'/alignments/alignment_run/',
     alignments_by_alignment_run_url         => $self->o('rest_server').'/alignments/alignment/alignment_run/',
-    set_alignment_status_url                => $self->o('rest_server'),
+    set_alignment_status_url                => $self->o('rest_server').'/ensembl/species_history/',
   };
 }
 

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -195,7 +195,7 @@ sub pipeline_analyses {
                                  'uniprot_file_swissprot: "#uniprot_sp_file#", '.
                                  'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
                                  'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                 'ensembl_release: '.$self->o('ensembl_release').' }\')'.
+                                 'ensembl_release: #release# }\')'.
                                '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
                                ' | jq -r \'.alignment_run_id\');'. # wget should return a json containing the alignment_run_id created
                                
@@ -253,7 +253,7 @@ sub pipeline_analyses {
                                ' -registry_port '.$self->o('registry_port').
                                ' -user '.$self->o('userstamp').
                                ' -species #species#'.
-                               ' -release '.$self->o('ensembl_release').
+                               ' -release #release#'.
                                ' -release_mapping_history_id $RELEASEMAPPINGHISTORYID'.
                                ' -uniprot_sp_file #uniprot_sp_file#'.
                                ' -uniprot_sp_isoform_file #uniprot_sp_isoform_file#'.
@@ -292,7 +292,7 @@ sub pipeline_analyses {
                                  'uniprot_file_swissprot: "#uniprot_sp_file#", '.
                                  'uniprot_file_isoform: "#uniprot_sp_isoform_file#", '.
                                  'uniprot_dir_trembl: "#uniprot_tr_dir#", '.
-                                 'ensembl_release: '.$self->o('ensembl_release').' }\')'.
+                                 'ensembl_release: #release# }\')'.
                                '" --header=Content-Type:application/json '.$self->o('alignment_run_url').
                                ' | jq -r \'.alignment_run_id\''. # wget should return a json containing the alignment_run_id created
                                

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -47,10 +47,10 @@ sub default_options {
     ],
 
     # Parameters to track submissions
-    tag       => undef,
-    email     => undef,
-    release   => undef,
-    timestamp => undef,
+    tag             => undef,
+    email           => undef,
+    ensembl_release => undef,
+    timestamp       => undef,
 
     # Switch off automatic retries
     hive_default_max_retry_count => 0,
@@ -76,7 +76,7 @@ sub pipeline_create_commands {
       job_id INT PRIMARY KEY,
       tag VARCHAR(255) NULL,
       email VARCHAR(255) NULL,
-      release INT NOT NULL,
+      ensembl_release INT NOT NULL,
       submitted VARCHAR(255) NULL
     );
   /;

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =cut
 
-package HiveLoadGIFTS_conf;
+package Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_conf;
 
 use warnings;
 use strict;

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -48,8 +48,9 @@ sub default_options {
 
     # Parameters to track submissions
     tag       => undef,
-    timestamp => undef,
     email     => undef,
+    release   => undef,
+    timestamp => undef,
 
     # Switch off automatic retries
     hive_default_max_retry_count => 0,
@@ -75,6 +76,7 @@ sub pipeline_create_commands {
       job_id INT PRIMARY KEY,
       tag VARCHAR(255) NULL,
       email VARCHAR(255) NULL,
+      release INT NOT NULL,
       submitted VARCHAR(255) NULL
     );
   /;

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -50,6 +50,7 @@ sub default_options {
     tag             => undef,
     email           => undef,
     ensembl_release => undef,
+    rest_server     => undef,
     timestamp       => undef,
 
     # Switch off automatic retries

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -94,7 +94,7 @@ sub pipeline_analyses {
                                'perl '.$self->o('import_species_script').
                                ' -user '.$self->o('userstamp').
                                ' -species #species#'.
-                               ' -release '.$self->o('ensembl_release').
+                               ' -release #release#'.
                                ' -registry_host '.$self->o('registry_host').
                                ' -registry_user '.$self->o('registry_user').
                                ' -registry_port '.$self->o('registry_port').

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -75,6 +75,7 @@ sub pipeline_analyses {
                        tag             => $self->o('tag'),
                        email           => $self->o('email'),
                        ensembl_release => $self->o('ensembl_release'),
+                       rest_server     => $self->o('rest_server'),
                        timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',
@@ -99,7 +100,7 @@ sub pipeline_analyses {
                                ' -registry_host '.$self->o('registry_host').
                                ' -registry_user '.$self->o('registry_user').
                                ' -registry_port '.$self->o('registry_port').
-                               ' -rest_server '.$self->o('rest_server').
+                               ' -rest_server #rest_server#'.
                                ' > #output_dir#/#import_species_data_file#'
                      },
       -rc_name    => 'default_20GB',

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
- HiveLoadGIFTS_genes_conf
+ Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_genes_conf
 
 =head1 DESCRIPTION
 
@@ -32,13 +32,13 @@ limitations under the License.
 
 =cut
 
-package HiveLoadGIFTS_genes_conf;
+package Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_genes_conf;
 
 use warnings;
 use strict;
 use feature 'say';
 
-use base ('HiveLoadGIFTS_conf');
+use base ('Bio::EnsEMBL::GIFTS::PipeConfig::HiveLoadGIFTS_conf');
 
 sub default_options {
   my ($self) = @_;

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -27,7 +27,6 @@ limitations under the License.
   -registry_host    mysql server with core databases
   -registry_port    mysql port number
   -registry_user    read-only user
-  -rest_server      GIFTS REST API server URL
   -base_output_dir  Location of output files
 
 =cut

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -73,8 +73,9 @@ sub pipeline_analyses {
                        species_list    => $self->o('species_list'),
                        base_output_dir => $self->o('base_output_dir'),
                        tag             => $self->o('tag'),
-                       timestamp       => $self->o('timestamp'),
                        email           => $self->o('email'),
+                       release         => $self->o('release'),
+                       timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',
       -flow_into  => {

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -74,7 +74,7 @@ sub pipeline_analyses {
                        base_output_dir => $self->o('base_output_dir'),
                        tag             => $self->o('tag'),
                        email           => $self->o('email'),
-                       release         => $self->o('release'),
+                       ensembl_release => $self->o('ensembl_release'),
                        timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',
@@ -95,7 +95,7 @@ sub pipeline_analyses {
                                'perl '.$self->o('import_species_script').
                                ' -user '.$self->o('userstamp').
                                ' -species #species#'.
-                               ' -release #release#'.
+                               ' -release #ensembl_release#'.
                                ' -registry_host '.$self->o('registry_host').
                                ' -registry_user '.$self->o('registry_user').
                                ' -registry_port '.$self->o('registry_port').

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -63,7 +63,7 @@ sub write_output {
     tag             => $tag,
     email           => $email,
     ensembl_release => $ensembl_release,
-    submitted       => $timestamp,
+    submitted       => $submitted,
   );
   $self->dataflow_output_id(\%submission_output, 1);
 

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -50,12 +50,12 @@ sub write_output {
   }
 
   my $tag             = $self->param('tag');
-  my $email           = $self->param('email');
-  my $ensembl_release = $self->param('ensembl_release');
-  my $rest_server     = $self->param('rest_server');
-  my $submitted       = $self->param('timestamp');
-  my $base_output_dir = $self->param('base_output_dir');
-  my $species_list    = $self->param('species_list');
+  my $email           = $self->param_required('email');
+  my $ensembl_release = $self->param_required('ensembl_release');
+  my $rest_server     = $self->param_required('rest_server');
+  my $submitted       = $self->param_required('timestamp');
+  my $base_output_dir = $self->param_required('base_output_dir');
+  my $species_list    = $self->param_required('species_list');
 
   # A subset of the input parameters are stored in the 'gifts_submission'
   # table, for easier subsequent retrieval than querying the native hive tables.

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -1,0 +1,84 @@
+=head1 LICENSE
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::GIFTS::Submit
+
+=head1 DESCRIPTION
+Perform housekeeping tasks that make it easier to seed jobs.
+
+=cut
+
+package Bio::EnsEMBL::GIFTS::Submit;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use JSON;
+use Path::Tiny;
+use Time::Piece;
+
+use base ('Bio::EnsEMBL::Hive::Process');
+
+sub write_output {
+  my $self = shift;
+
+  # This module is a single point of entry into the pipeline, to enable
+  # an eternal beekeeper to be seeded with multiple runs.
+  # Pipeline-wide parameter propagation is switched on, so we just need
+  # to pass on all the input parameters in order for subsequent modules
+  # to have the data they need. There's no way in hive to get all the
+  # parameters in a data structure, so need to do it the long-winded way,
+  # which does at least make it explicit what we're doing...
+  # We also add the job_id for this analysis, in order to be able to
+  # associate results summaries with the relevant submission.
+
+  unless (defined $self->param('timestamp')) {
+    $self->param('timestamp', localtime->cdate);
+  }
+
+  # A subset of the input parameters are stored in the 'gifts_submission'
+  # table, for easier subsequent retrieval than querying the native hive tables.
+  my %submission_output = (
+    job_id    => $self->input_job->dbID,
+    tag       => $self->param('tag'),
+    email     => $self->param('email'),
+    submitted => $self->param('timestamp'),
+  );
+  $self->dataflow_output_id(\%submission_output, 1);
+
+  my $species_list = $self->param('species_list');
+  foreach (@$species_list) {
+    my $assembly   = $$_{'assembly'};
+    my $species    = $$_{'species'};
+    my $output_dir = $self->param('base_output_dir')."/$species";
+
+    my $species_output = {
+      assembly   => $assembly,
+      species    => $species,
+      output_dir => $output_dir,
+    };
+    $self->dataflow_output_id($species_output, 2);
+  }
+
+  my %notify_output = (
+    %submission_output,
+    base_output_dir => $self->param('base_output_dir'),
+  );
+  $self->dataflow_output_id(\%notify_output, 3);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -56,6 +56,7 @@ sub write_output {
     job_id    => $self->input_job->dbID,
     tag       => $self->param('tag'),
     email     => $self->param('email'),
+    release   => $self->param('release'),
     submitted => $self->param('timestamp'),
   );
   $self->dataflow_output_id(\%submission_output, 1);
@@ -69,6 +70,7 @@ sub write_output {
     my $species_output = {
       assembly   => $assembly,
       species    => $species,
+      release    => $self->param('release'),
       output_dir => $output_dir,
     };
     $self->dataflow_output_id($species_output, 2);

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -65,7 +65,7 @@ sub write_output {
   foreach (@$species_list) {
     my $assembly   = $$_{'assembly'};
     my $species    = $$_{'species'};
-    my $output_dir = $self->param('base_output_dir')."/$species";
+    my $output_dir = $self->param('base_output_dir')."/$release/$species";
 
     my $species_output = {
       assembly   => $assembly,

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -52,6 +52,7 @@ sub write_output {
   my $tag             = $self->param('tag');
   my $email           = $self->param('email');
   my $ensembl_release = $self->param('ensembl_release');
+  my $rest_server     = $self->param('rest_server');
   my $submitted       = $self->param('timestamp');
   my $base_output_dir = $self->param('base_output_dir');
   my $species_list    = $self->param('species_list');
@@ -63,6 +64,7 @@ sub write_output {
     tag             => $tag,
     email           => $email,
     ensembl_release => $ensembl_release,
+    rest_server     => $rest_server,
     submitted       => $submitted,
   );
   $self->dataflow_output_id(\%submission_output, 1);
@@ -77,6 +79,7 @@ sub write_output {
       assembly        => $assembly,
       species         => $species,
       ensembl_release => $ensembl_release,
+      rest_server     => $rest_server,
       output_dir      => $output_dir,
     };
     $self->dataflow_output_id($species_output, 2);

--- a/scripts/ensembl_import_species_data.pl
+++ b/scripts/ensembl_import_species_data.pl
@@ -271,6 +271,6 @@ if (scalar(@json_genes)) {
 }
 
 # display counts
-print "Genes:".$gene_count."\n.";
-print "Transcripts:".$transcript_count."\n.";
-print "Finished\n.";
+print "Genes:".$gene_count."\n";
+print "Transcripts:".$transcript_count."\n";
+print "Finished\n";


### PR DESCRIPTION
Restructuring pipeline to enable it to sit behind a service in 'eternal beekeeper' mode. This requires a couple of extra tables for tracking purposes, a new submission module, and rearranging how parameters are passed. Added an email notification module. Inherited from hive Ensembl config, which takes care of some standard pipeline parameters so that we don't need to configure them here. Removed some mandatory parameters from the defaults, so that the pipeline initialisation fails if they are missing, rather then the failures being deferred until the scripts try to run without them.