### PR TITLE
The 'userstamp' value must not be more than 15 characters in length.

### DIFF
--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -31,7 +31,8 @@ sub default_options {
     %{$self->SUPER::default_options},
 
     # Username to be registered as the one loading the Ensembl data
-    userstamp => 'ensembl_gifts_loading_pipeline',
+    # Must not exceed 15 characters in length
+    userstamp => 'gifts_pipeline',
 
     # In order to seed the database multiple times, we need the
     # species list here, rather than specified via 'input_id'.

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_conf.pm
@@ -52,6 +52,7 @@ sub default_options {
     email           => undef,
     ensembl_release => undef,
     rest_server     => undef,
+    auth_token      => undef,
     timestamp       => undef,
 
     # Switch off automatic retries

--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_genes_conf.pm
@@ -75,7 +75,7 @@ sub pipeline_analyses {
                        email           => $self->o('email'),
                        ensembl_release => $self->o('ensembl_release'),
                        rest_server     => $self->o('rest_server'),
-                       auth_token     => $self->o('auth_token'),
+                       auth_token      => $self->o('auth_token'),
                        timestamp       => $self->o('timestamp'),
                      },
       -rc_name    => 'default',

--- a/modules/Bio/EnsEMBL/GIFTS/Submit.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Submit.pm
@@ -53,6 +53,7 @@ sub write_output {
   my $email           = $self->param_required('email');
   my $ensembl_release = $self->param_required('ensembl_release');
   my $rest_server     = $self->param_required('rest_server');
+  my $auth_token      = $self->param_required('auth_token');
   my $submitted       = $self->param_required('timestamp');
   my $base_output_dir = $self->param_required('base_output_dir');
   my $species_list    = $self->param_required('species_list');
@@ -65,6 +66,7 @@ sub write_output {
     email           => $email,
     ensembl_release => $ensembl_release,
     rest_server     => $rest_server,
+    auth_token      => $auth_token,
     submitted       => $submitted,
   );
   $self->dataflow_output_id(\%submission_output, 1);
@@ -80,6 +82,7 @@ sub write_output {
       species         => $species,
       ensembl_release => $ensembl_release,
       rest_server     => $rest_server,
+      auth_token      => $auth_token,
       output_dir      => $output_dir,
     };
     $self->dataflow_output_id($species_output, 2);


### PR DESCRIPTION
The 'userstamp' value must not be more than 15 characters in length. 
Add parameters to 'Submit' module for handling authentication, set to undef by default.

