### PR TITLE
Reformat output of final pipeline 'notification' analysis

### DIFF
--- a/modules/Bio/EnsEMBL/GIFTS/Notify.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/Notify.pm
@@ -28,6 +28,8 @@ use warnings;
 use feature 'say';
 
 use File::Spec::Functions qw(catdir);
+use JSON qw(encode_json);
+use Time::Piece;
 
 use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
 
@@ -44,11 +46,16 @@ sub write_output {
   my $self = shift;
 
   my $output = {
-    job_id => $self->param('job_id'),
-    output => $self->param('base_output_dir'),
+    output_dir => $self->param('base_output_dir'),
+    timestamp  => localtime->cdate
   };
 
-  $self->dataflow_output_id($output, 1);
+  my $result = {
+    job_id => $self->param('job_id'),
+    output => encode_json($output),
+  };
+
+  $self->dataflow_output_id($result, 1);
 }
 
 sub set_email_parameters {


### PR DESCRIPTION
The output needs to be json-format, in order for the app to return the data correctly - not doing this was causing an error in the display of job results.