### PR TITLE
Remove surplus flow to notify module.

### DIFF
--- a/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
+++ b/modules/Bio/EnsEMBL/GIFTS/PipeConfig/HiveLoadGIFTS_alignments_conf.pm
@@ -373,7 +373,6 @@ sub pipeline_analyses {
                                '$ENSEMBLSPECIESHISTORYID/alignment_status/ALIGNMENT_COMPLETED/ '
                      },
       -rc_name    => 'default',
-      -flow_into => { 1 => ['notify'] },
     },
     
     {


### PR DESCRIPTION
In a previous iteration of the pipeline we had notification on a per-species basis, but that didn't work very well, so we switched back to per-submission. But there was still a stray flow to the notify analysis that was causing errors.